### PR TITLE
php-8 preg_split uses -1 instead of null now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/lib/LiquidRegexp.class.php
+++ b/lib/LiquidRegexp.class.php
@@ -4,7 +4,7 @@
  * non liquid specific support classes and functions.
  *
  * @package Liquid
- * @copyright Copyright (c) 2011-2012 Harald Hanek, 
+ * @copyright Copyright (c) 2011-2012 Harald Hanek,
  * fork of php-liquid (c) 2006 Mateo Murphy,
  * based on Liquid for Ruby (c) 2006 Tobias Luetke
  * @license http://harrydeluxe.mit-license.org
@@ -114,7 +114,7 @@ class LiquidRegexp
      * @param int $limit Limits the amount of results returned
      * @return array
      */
-    function split($string, $limit = null)
+    function split($string, $limit = -1)
     {
         return preg_split($this->pattern, $string, $limit);
     }

--- a/lib/LiquidTemplate.class.php
+++ b/lib/LiquidTemplate.class.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * The template class.
- * 
- * @example 
+ *
+ * @example
  * $tpl = new LiquidTemplate();
  * $tpl->parse(template_source);
  * $tpl->render(array('foo'=>1, 'bar'=>2);
  *
  * @package Liquid
- * @copyright Copyright (c) 2011-2012 Harald Hanek, 
+ * @copyright Copyright (c) 2011-2012 Harald Hanek,
  * fork of php-liquid (c) 2006 Mateo Murphy,
  * based on Liquid for Ruby (c) 2006 Tobias Luetke
  * @license http://harrydeluxe.mit-license.org
@@ -54,7 +54,7 @@ class LiquidTemplate
 
 
     /**
-     * 
+     *
      *
      */
     public function setFileSystem($fileSystem)
@@ -64,7 +64,7 @@ class LiquidTemplate
 
 
     /**
-     * 
+     *
      *
      */
     public function setCache($cache)
@@ -87,7 +87,7 @@ class LiquidTemplate
 
 
     /**
-     * 
+     *
      *
      * @return object
      */
@@ -98,7 +98,7 @@ class LiquidTemplate
 
 
     /**
-     * 
+     *
      *
      * @return LiquidDocument
      */
@@ -121,7 +121,7 @@ class LiquidTemplate
 
 
     /**
-     * 
+     *
      *
      * @return array
      */
@@ -150,7 +150,7 @@ class LiquidTemplate
      */
     public static function tokenize($source)
     {
-        return (!$source) ? array() : preg_split(LIQUID_TOKENIZATION_REGEXP, $source, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        return (!$source) ? array() : preg_split(LIQUID_TOKENIZATION_REGEXP, $source, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
     }
 
 


### PR DESCRIPTION
## Link to task

> 

## Developers checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have reviewed it myself to ensure I have not overlooked something obvious 😂
- [ ] I have written unit tests
- [ ] I have tried it myself on staging before moving the task to review
---
<sup>Read about definition of done in this [RFC](https://www.notion.so/billysbilling/Definition-of-Done-e5552df1a2494c21976fc2f3dcd8d665)</sup>